### PR TITLE
Fix rule reset logic to sync local data

### DIFF
--- a/src/lib/rulesUtils.ts
+++ b/src/lib/rulesUtils.ts
@@ -2,6 +2,8 @@
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
 import { getErrorMessage } from '@/lib/errors';
+import { loadRulesFromDB, saveRulesToDB } from '@/data/indexedDB/useIndexedDB';
+import { Rule } from '@/data/interfaces/Rule';
 
 /**
  * Reset rule usage data for rules with specified frequency
@@ -10,18 +12,55 @@ import { getErrorMessage } from '@/lib/errors';
 export const resetRuleUsageData = async (frequency: 'daily' | 'weekly'): Promise<void> => {
   try {
     logger.debug(`[resetRuleUsageData] Resetting ${frequency} rule usage data`);
-    
-    const { error } = await supabase
-      .from('rules')
-      .update({ usage_data: [] })
-      .eq('frequency', frequency);
 
-    if (error) {
-      logger.error(`[resetRuleUsageData] Error resetting ${frequency} rule usage data:`, error);
-      throw error;
+    const {
+      data: { session }
+    } = await supabase.auth.getSession();
+
+    if (!session?.user) {
+      logger.debug('[resetRuleUsageData] No authenticated user, skipping reset');
+      return;
     }
 
-    logger.debug(`[resetRuleUsageData] Successfully reset ${frequency} rule usage data`);
+    const { data: rules, error } = await supabase
+      .from('rules')
+      .select('*')
+      .eq('frequency', frequency)
+      .eq('user_id', session.user.id);
+
+    if (error) {
+      logger.error(`[resetRuleUsageData] Error fetching ${frequency} rules:`, error);
+      return;
+    }
+
+    if (!rules || rules.length === 0) {
+      logger.debug(`[resetRuleUsageData] No ${frequency} rules found to reset`);
+      return;
+    }
+
+    const { data: updatedRules, error: updateError } = await supabase
+      .from('rules')
+      .update({ usage_data: [] })
+      .in('id', rules.map(rule => rule.id))
+      .eq('user_id', session.user.id)
+      .select('*');
+
+    if (updateError) {
+      logger.error(`[resetRuleUsageData] Error resetting ${frequency} rules:`, updateError);
+      throw updateError;
+    }
+
+    logger.debug(`[resetRuleUsageData] Successfully reset ${updatedRules?.length ?? 0} ${frequency} rules`);
+
+    if (updatedRules) {
+      const currentLocalRules = (await loadRulesFromDB()) || [];
+      const updatedLocalRules = currentLocalRules.map(localRule => {
+        const resetRule = updatedRules.find(ur => ur.id === localRule.id);
+        return resetRule ? (resetRule as Rule) : localRule;
+      });
+      await saveRulesToDB(updatedLocalRules);
+      logger.debug('[resetRuleUsageData] Synced reset rules to IndexedDB');
+    }
   } catch (error) {
     logger.error(`[resetRuleUsageData] Failed to reset ${frequency} rule usage data:`, getErrorMessage(error));
     throw error;
@@ -31,7 +70,8 @@ export const resetRuleUsageData = async (frequency: 'daily' | 'weekly'): Promise
 /**
  * Check if rule resets are needed and perform them
  */
-export const checkAndPerformRuleResets = async (): Promise<void> => {
+export const checkAndPerformRuleResets = async (): Promise<boolean> => {
+  let resetPerformed = false;
   try {
     const now = new Date();
     const currentWeek = getWeekNumber(now);
@@ -45,6 +85,7 @@ export const checkAndPerformRuleResets = async (): Promise<void> => {
       logger.debug('[checkAndPerformRuleResets] Performing daily rule reset');
       await resetRuleUsageData('daily');
       localStorage.setItem('lastDailyRuleReset', currentDay);
+      resetPerformed = true;
     }
 
     // Check for weekly reset (reset on Monday)
@@ -52,10 +93,12 @@ export const checkAndPerformRuleResets = async (): Promise<void> => {
       logger.debug('[checkAndPerformRuleResets] Performing weekly rule reset');
       await resetRuleUsageData('weekly');
       localStorage.setItem('lastWeeklyRuleReset', currentWeek.toString());
+      resetPerformed = true;
     }
+    return resetPerformed;
   } catch (error) {
     logger.error('[checkAndPerformRuleResets] Error during rule resets:', getErrorMessage(error));
-    // Don't throw - we don't want to break the app if reset fails
+    return false;
   }
 };
 


### PR DESCRIPTION
## Summary
- ensure rule resets are scoped to the current user and synced to IndexedDB
- indicate whether a reset occurred in `checkAndPerformRuleResets`
- update `useRulesData` to reload fresh rule data only when a reset happened

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68400961313c832dbcaa0f208e44f108